### PR TITLE
have react as peerDependency and devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "url": "https://github.com/CourtHive/tods-score-grid/issues"
   },
   "homepage": "https://courthive.github.io/tods-score-grid",
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
   "dependencies": {
     "@radix-ui/colors": "^0.1.7",
     "@radix-ui/react-dropdown-menu": "^0.1.1",
@@ -50,9 +54,7 @@
     "@stitches/react": "^1.2.5",
     "classnames": "^2.3.1",
     "dayjs": "^1.10.7",
-    "react": "^17.0.2",
     "react-country-flag": "3.0.2",
-    "react-dom": "^17.0.2",
     "tods-competition-factory": "0.283.0"
   },
   "devDependencies": {
@@ -111,6 +113,8 @@
     "prettier": "2.7.1",
     "prettier-eslint": "13.0.0",
     "prop-types": "15.8.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-dropzone": "11.7.1",
     "rollup": "2.77.2",
     "rollup-plugin-terser": "7.0.2",


### PR DESCRIPTION
For reusable components, is way better to have the react dependency in both peerDependencies and devDependencies.

peerDependencies specify which version(s) of React your reusable component supports/requires.

devDependencies ensures React will be installed when you run npm install while developing your component, or when running tests.

Putting react in dependencies will cause multiple versions of React to be installed if somebody uses your component but has a different version of React in their own package.json - having multiple versions of React not only bloats the build, but also causes errors when different versions try to interact.